### PR TITLE
Use a different technique to spot header rows

### DIFF
--- a/sageiaticreator/query/transactions.py
+++ b/sageiaticreator/query/transactions.py
@@ -173,11 +173,14 @@ def get_sheet_data(organisation_slug, file):
     
     for row_number in range(0, num_rows):
         cv = sheet.cell_value(row_number, 1)
-        if cv == "N/C:":
-            account_number = sheet.cell_value(row_number, 2)
-            account_description =  sheet.cell_value(row_number, 6)
-            continue
-            
+        if cv in ("", "N/C:",):
+            an = sheet.cell_value(row_number, 2)
+            ad = sheet.cell_value(row_number, 6)
+            if an != "" and ad != "":
+                account_number = an
+                account_description = ad
+                continue
+
         # Ignore header rows and blank rows
         if str(cv).startswith("No") or (cv == ""):
             continue


### PR DESCRIPTION
Instead of just searching for the string "N/C:" in the 2nd column, this also accepts a blank second column cell value provided an account number and account description are both present.

Fixes #8.
